### PR TITLE
Use SHA256 base64 encoded digest for file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+uri-cache-0.0.1.gem

--- a/lib/uri-cache.rb
+++ b/lib/uri-cache.rb
@@ -7,10 +7,11 @@
 
 require 'open-uri'
 require 'fileutils'
-require 'cgi'
+require 'digest'
 
 class URICache
 
+  SCHEME="sha256"
 
   def initialize(location)
     @location = location
@@ -18,7 +19,7 @@ class URICache
   end
 
   def uri_location(uri)
-    c_uri = CGI.escape uri
+    c_uri = Digest::SHA256.base64digest(uri+SCHEME)
     "#{@location}/#{c_uri}"
   end
 

--- a/uri-cache.gemspec
+++ b/uri-cache.gemspec
@@ -4,8 +4,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'uri-cache'
-  s.version     = '0.0.1'
-  s.date        = '2020-12-24'
+  s.version     = '0.0.2'
+  s.date        = '2024-04-27'
   s.summary     = 'URI cache'
   s.description = 'Simple URI cache'
   s.authors     = ['Daniel Kelley']


### PR DESCRIPTION
URICache.uri_location()
  Use digest for filename instead of URI directly
  This overcomes file name length limitations for long URIs

Update gem version
Add .gitignore

Fixes #2